### PR TITLE
Memory check is for at least 64MB or more

### DIFF
--- a/admin/tab-system_status.php
+++ b/admin/tab-system_status.php
@@ -102,7 +102,7 @@
 		<td>
 			<?php
 
-			if ( $memory > 67108864 ) { // 64 MB
+			if ( $memory >= 67108864 ) { // 64 MB
 				echo '&#10003;';
 			} else {
 				echo wp_kses(


### PR DESCRIPTION
Without the 64 it only check for 64 and more, right?